### PR TITLE
Update FrontBuilding

### DIFF
--- a/game/FrontBuilding.gd
+++ b/game/FrontBuilding.gd
@@ -1,28 +1,21 @@
 class_name FrontBuilding
 extends Area2D
 
-const FOREGROUND_BUILDING_TYPES_COUNT: int = 3
-var dead = true
 var width: int
-@onready var sprite = $Sprite2D
+@export var textures: Array[Texture2D]
+@onready var sprite: Sprite2D = $Sprite2D
+@onready var collision: CollisionShape2D = $CollisionShape2D
 
 func _ready():
-	var index = randi() % FOREGROUND_BUILDING_TYPES_COUNT
-	sprite.texture = load("res://assets/foreground_building_" + str(index) + ".png")
-	sprite.show()
-	var height = sprite.texture.get_height()
+	sprite.texture = textures.pick_random()
+	@warning_ignore("integer_division")
 	width = sprite.texture.get_width() / sprite.hframes
+	var height = sprite.texture.get_height()
 	sprite.position.y = -height * 0.5
 
-	var collision = CollisionShape2D.new()
-	self.add_child(collision)
-	var shape = RectangleShape2D.new()
-	shape.extents = Vector2(width * 0.5, height * 0.5)
+	collision.shape.extents = Vector2(width * 0.5, height * 0.5)
 	collision.position = sprite.position
-	collision.shape = shape
-	
-	set_collision_layer_value(2, true)
 
 func destroy():
-	set_collision_layer_value(2, false)
+	monitorable = false
 	$AnimationPlayer.play("destroy_building")

--- a/game/FrontBuilding.tscn
+++ b/game/FrontBuilding.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://dqyyvmnjldxta"]
+[gd_scene load_steps=10 format=3 uid="uid://dqyyvmnjldxta"]
 
 [ext_resource type="Script" path="res://game/FrontBuilding.gd" id="1"]
 [ext_resource type="Script" path="res://game/AutoDeletable.gd" id="2_e75p7"]
+[ext_resource type="Texture2D" uid="uid://d1d84pqvdlv5c" path="res://assets/foreground_building_0.png" id="2_p4hbp"]
+[ext_resource type="Texture2D" uid="uid://damgeq2watpkt" path="res://assets/foreground_building_1.png" id="3_ram8t"]
+[ext_resource type="Texture2D" uid="uid://b8ae01jc0v56w" path="res://assets/foreground_building_2.png" id="4_dhfdf"]
 
 [sub_resource type="Animation" id="1"]
 resource_name = "destroy_building"
@@ -40,11 +43,16 @@ _data = {
 "reset": SubResource("2")
 }
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_75ih8"]
+resource_local_to_scene = true
+
 [node name="FrontBuilding" type="Area2D"]
 collision_layer = 4
 collision_mask = 0
+input_pickable = false
 monitoring = false
 script = ExtResource("1")
+textures = Array[Texture2D]([ExtResource("2_p4hbp"), ExtResource("3_ram8t"), ExtResource("4_dhfdf")])
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 hframes = 3
@@ -56,3 +64,6 @@ libraries = {
 
 [node name="AutoDeletable" type="Node" parent="."]
 script = ExtResource("2_e75p7")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_75ih8")

--- a/game/enemies/Bomb.tscn
+++ b/game/enemies/Bomb.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Texture2D" uid="uid://i12q10ttsgri" path="res://assets/bomb.png" id="1"]
 [ext_resource type="Script" path="res://game/enemies/Bomb.gd" id="2"]
-[ext_resource type="PackedScene" path="res://game/HealthBar.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://bs77dd6d7fpv8" path="res://game/HealthBar.tscn" id="3"]
 [ext_resource type="Script" path="res://game/AutoDeletable.gd" id="4"]
 
 [sub_resource type="RectangleShape2D" id="1"]

--- a/game/peron/Peron.gd
+++ b/game/peron/Peron.gd
@@ -95,7 +95,7 @@ func anim_callback_arm_landed():
 	var areas = $arm_hit.get_overlapping_areas()
 	for area in areas:
 		var building = area as FrontBuilding
-		if building:
+		if building and building.monitorable:
 			building.destroy()
 
 func _on_Peron_area_entered(area):


### PR DESCRIPTION
Fixes collision disabling by using a workaround (checking for monitorable).

Updates sprite randomization to use a configurable array of textures.
![image](https://github.com/Hierophant-Games/mecha-peron-godot/assets/1460090/c0e1bfc4-74f0-41a1-9e4a-cd97b045295f)

Replaces node creation on code with scene configuration.

