### PR TITLE
Adds CannonBomb, sets it to be spawned and shot at Peron from cannon

### DIFF
--- a/game/EnemyProjectile.gd
+++ b/game/EnemyProjectile.gd
@@ -16,6 +16,6 @@ func _process(delta):
 	owner.position += velocity * delta
 
 func _on_area_entered(area):
-	if area.owner is Peron:
+	if area.owner.has_method("damage"):
 		area.owner.damage(damage)
 	destroy()

--- a/game/Foreground.gd
+++ b/game/Foreground.gd
@@ -3,10 +3,14 @@ extends Node2D
 
 var FrontBuildingScene = preload("res://game/FrontBuilding.tscn")
 
+var main_layer: WeakRef
+var target: Area2D
+
 @onready var next_building_spawn_pos_x = random_offset()
-var should_spawn_cannon = false
 @export var building_textures: Array[Texture2D]
+
 var last_texture_path = ""
+var should_spawn_cannon = false
 
 func update_buildings(screen_right):
 	while next_building_spawn_pos_x < screen_right:
@@ -19,7 +23,7 @@ func update_buildings(screen_right):
 		last_texture_path = texture.resource_path
 		
 		# setup building
-		new_building.setup(texture, should_spawn_cannon)
+		new_building.setup(texture, should_spawn_cannon, target, main_layer)
 		
 		# if spawning a cannon, we don't need to do so for a while
 		if should_spawn_cannon:

--- a/game/FrontBuilding.gd
+++ b/game/FrontBuilding.gd
@@ -8,7 +8,7 @@ var width: int
 @onready var collision: CollisionShape2D = $CollisionShape2D
 var cannon: Cannon = null
 
-func setup(texture: Texture2D, should_spawn_cannon: bool):
+func setup(texture: Texture2D, should_spawn_cannon: bool, target: Area2D, main_layer: WeakRef):
 	sprite.texture = texture
 	
 	@warning_ignore("integer_division")
@@ -23,6 +23,8 @@ func setup(texture: Texture2D, should_spawn_cannon: bool):
 	
 	if should_spawn_cannon:
 		cannon = CannonScene.instantiate()
+		cannon.main_layer = main_layer
+		cannon.target = target
 		add_child(cannon)
 		cannon.position.y = sprite.position.y
 

--- a/game/enemies/Cannon.gd
+++ b/game/enemies/Cannon.gd
@@ -1,7 +1,10 @@
 class_name Cannon
 extends Entity
 
+var CannonBombScene:= preload("res://game/enemies/CannonBomb.tscn")
 var attack_timer: float = 0
+var main_layer: WeakRef
+var target: Area2D
 
 func _ready():
 	$CannonSprite.show()
@@ -27,6 +30,13 @@ func _process(_delta):
 		$AnimationPlayer.play(prefix + "_top_left")
 	else:
 		$AnimationPlayer.play(prefix + "_top")
+
+func spawn_bomb():
+	var bomb: CannonBomb = CannonBombScene.instantiate() as CannonBomb
+	bomb.target = target
+	main_layer.get_ref().add_child(bomb)
+	bomb.global_position = $BombSpawnNode.global_position
+	bomb.fly()
 
 func destroy():
 	destroyed = true

--- a/game/enemies/Cannon.tscn
+++ b/game/enemies/Cannon.tscn
@@ -4,7 +4,6 @@
 [ext_resource type="Texture2D" uid="uid://bvsig5d4ekwfy" path="res://assets/cannon.png" id="2_v2xqr"]
 [ext_resource type="Texture2D" uid="uid://d0hiemg3b3jin" path="res://assets/explosion.png" id="3_ns7hl"]
 
-
 [sub_resource type="Animation" id="Animation_x8b3n"]
 resource_name = "explode"
 length = 0.44
@@ -60,6 +59,18 @@ tracks/0/keys = {
 "update": 1,
 "values": [0]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("BombSpawnNode:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-9, -13)]
+}
 
 [sub_resource type="Animation" id="Animation_pfl66"]
 resource_name = "idle_top"
@@ -75,6 +86,18 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 1,
 "values": [4]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("BombSpawnNode:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-2.5, -17)]
 }
 
 [sub_resource type="Animation" id="Animation_cm472"]
@@ -92,6 +115,18 @@ tracks/0/keys = {
 "update": 1,
 "values": [2]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("BombSpawnNode:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-2.5, -17)]
+}
 
 [sub_resource type="Animation" id="Animation_qlme0"]
 resource_name = "shoot_left"
@@ -107,6 +142,32 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 1,
 "values": [0, 1]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("BombSpawnNode:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-9, -13)]
+}
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.3),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"spawn_bomb"
+}]
 }
 
 [sub_resource type="Animation" id="Animation_faxh4"]
@@ -124,6 +185,32 @@ tracks/0/keys = {
 "update": 1,
 "values": [4, 5]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("BombSpawnNode:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-2.5, -13)]
+}
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.3),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"spawn_bomb"
+}]
+}
 
 [sub_resource type="Animation" id="Animation_c6dwa"]
 resource_name = "shoot_top_left"
@@ -139,6 +226,32 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 1,
 "values": [2, 3]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("BombSpawnNode:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-2.5, -17)]
+}
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.3),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"spawn_bomb"
+}]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_nuhau"]
@@ -167,11 +280,15 @@ texture = ExtResource("3_ns7hl")
 centered = false
 hframes = 6
 vframes = 2
+frame = 10
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
 "": SubResource("AnimationLibrary_nuhau")
 }
 autoplay = "idle_left"
+
+[node name="BombSpawnNode" type="Node2D" parent="."]
+position = Vector2(-9, -13)
 
 [connection signal="animation_finished" from="AnimationPlayer" to="." method="_on_animation_player_animation_finished"]

--- a/game/enemies/CannonBomb.gd
+++ b/game/enemies/CannonBomb.gd
@@ -1,0 +1,13 @@
+class_name CannonBomb
+extends Entity
+
+var target: Area2D
+
+func fly():
+	var projectile = $EnemyProjectile as EnemyProjectile
+	projectile.damage = Constants.CANNON_BOMB_DAMAGE
+	
+	var target_size = (target.shape_owner_get_shape(0, 0) as RectangleShape2D).size
+	var target_pos = target.global_position - Vector2(0, target_size.y)
+	
+	projectile.velocity = (target_pos - global_position).normalized() * Constants.CANNON_BOMB_SPEED

--- a/game/enemies/CannonBomb.tscn
+++ b/game/enemies/CannonBomb.tscn
@@ -1,0 +1,103 @@
+[gd_scene load_steps=11 format=3 uid="uid://l1qkrjpipmia"]
+
+[ext_resource type="Script" path="res://game/enemies/CannonBomb.gd" id="1_fu5bi"]
+[ext_resource type="Texture2D" uid="uid://pqhd2lo56vg8" path="res://assets/cannonBomb.png" id="2_ukl0k"]
+[ext_resource type="PackedScene" uid="uid://bs77dd6d7fpv8" path="res://game/HealthBar.tscn" id="2_wlxlv"]
+[ext_resource type="Texture2D" uid="uid://d0hiemg3b3jin" path="res://assets/explosion.png" id="3_d6ebd"]
+[ext_resource type="Script" path="res://game/EnemyProjectile.gd" id="3_pf3mo"]
+[ext_resource type="Script" path="res://game/core/Damageable.gd" id="4_yn3pr"]
+[ext_resource type="Script" path="res://game/core/AutoDeletable.gd" id="5_yybm5"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_i4flo"]
+size = Vector2(18.4615, 19)
+
+[sub_resource type="Animation" id="Animation_5p5wc"]
+resource_name = "destroy"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("ExplosionSprite:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.04, 0.08, 0.12, 0.16, 0.2, 0.24, 0.28, 0.32, 0.36, 0.4),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("ExplosionSprite:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Sprite2D:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_xjdqy"]
+_data = {
+"destroy": SubResource("Animation_5p5wc")
+}
+
+[node name="CannonBomb" type="Node2D"]
+script = ExtResource("1_fu5bi")
+
+[node name="ExplosionSprite" type="Sprite2D" parent="."]
+visible = false
+texture = ExtResource("3_d6ebd")
+hframes = 6
+vframes = 2
+metadata/_edit_lock_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("2_ukl0k")
+
+[node name="Area2D" type="Area2D" parent="."]
+position = Vector2(-6, -12)
+scale = Vector2(0.26, 0.25)
+collision_layer = 2
+collision_mask = 64
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+position = Vector2(21.5385, 46.5)
+shape = SubResource("RectangleShape2D_i4flo")
+
+[node name="HealthBar" parent="." instance=ExtResource("2_wlxlv")]
+position = Vector2(-3, -5)
+scale = Vector2(0.25, 0.5)
+polygon = PackedVector2Array(0, 0, 20, 0, 20, 0.992402, 20, 2, 9.96875, 2, 0, 2)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_xjdqy")
+}
+
+[node name="EnemyProjectile" type="Node" parent="." node_paths=PackedStringArray("animation_player", "area_2d")]
+script = ExtResource("3_pf3mo")
+gravity = 0.0
+animation_player = NodePath("../AnimationPlayer")
+area_2d = NodePath("../Area2D")
+
+[node name="Damageable" type="Node" parent="." node_paths=PackedStringArray("destroyable", "health_bar")]
+script = ExtResource("4_yn3pr")
+destroyable = NodePath("../EnemyProjectile")
+health_bar = NodePath("../HealthBar")
+
+[node name="AutoDeletable" type="Node" parent="."]
+script = ExtResource("5_yybm5")

--- a/game/scenes/Level.gd
+++ b/game/scenes/Level.gd
@@ -14,6 +14,10 @@ var intro_state = PRE_INTRO
 @onready var peron: Peron = $Camera2D/ParallaxBackground/MainLayer/Peron as Peron
 @onready var camera = $Camera2D
 
+func _ready():
+	foreground.target = peron
+	foreground.main_layer = weakref(self.main_layer)
+
 func _process(_delta: float):
 	update_intro()
 	update_foreground()


### PR DESCRIPTION
Adds CannonBomb scene, it is an autodeletable, damageable enemy projectile that flies straight to it's target Adds necessary code to Cannon so it can spawn a CannonBomb Forwards necessary nodes to cannon so it can spawn a CannonBomb and shoot it at it's target Fixes circular reference by removing Peron reference from EnemyProjectile